### PR TITLE
Add `x86_64-unknown-theseus` target

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1041,6 +1041,8 @@ supported_targets! {
     ("x86_64-unknown-none", x86_64_unknown_none),
 
     ("mips64-openwrt-linux-musl", mips64_openwrt_linux_musl),
+    
+    ("x86_64-unknown-theseus", x86_64_unknown_theseus),
 }
 
 /// Cow-Vec-Str: Cow<'static, [Cow<'static, str>]>

--- a/compiler/rustc_target/src/spec/x86_64_unknown_theseus.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_theseus.rs
@@ -1,0 +1,19 @@
+use crate::spec::{Target, TargetOptions};
+
+pub fn target() -> Target {
+    let options = TargetOptions {
+        os: "theseus".into(),
+        features: "-mmx,-sse,+soft-float".into(),
+        has_thread_local: true,
+        disable_redzone: true,
+        ..Default::default()
+    };
+
+    Target {
+        llvm_target: "x86_64-unknown-theseus".into(),
+        pointer_width: 64,
+        data_layout: "e-m:e-i64:64-f80:128-n8:16:32:64-S128".into(),
+        arch: "x86_64".into(),
+        options,
+    }
+}


### PR DESCRIPTION
The target is based on [`Theseus/cfg/x86_64-theseus.json`](https://github.com/theseus-os/Theseus/blob/theseus_main/cfg/x86_64-theseus.json).

The difference between the existing `.json` file and new target spec can be viewed using `cargo t --manifest-path compiler/rustc_target/Cargo.toml -- --nocapture` and manually diffing the two debug outputs. The first is the original `.json` file, and the second is the updated target.

```diff
2c2
<     llvm_target: "x86_64-unknown-none-elf",
---
>     llvm_target: "x86_64-unknown-theseus",
66c66
<         has_thread_local: false,
---
>         has_thread_local: true,
```

`has_thread_local` was changed to `true` because as far as I understand, `theseus` supports thread locals. `hermit` sets `llvm-target` to `"x86_64-unknown-hermit"` (`compiler/rustc_target/src/spec/x86_64_unknown_hermit.rs`) so I don't think it matters.

Prior to merging, the following testing changes need to be reverted:
- [x] root `Cargo.toml` exclude
- [x] `supported_targets` macro making modules public
- [x] `theseus_target` test