### PR TITLE
Restore `--check-cfg` checks

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1476,11 +1476,11 @@ impl<'a> Builder<'a> {
         // features but cargo isn't involved in the #[path] process and so cannot pass the
         // complete list of features, so for that reason we don't enable checking of
         // features for std crates.
-        // cargo.arg(if mode != Mode::Std {
-        //     "-Zcheck-cfg=names,values,output,features"
-        // } else {
-        //     "-Zcheck-cfg=names,values,output"
-        // });
+        cargo.arg(if mode != Mode::Std {
+            "-Zcheck-cfg=names,values,output,features"
+        } else {
+            "-Zcheck-cfg=names,values,output"
+        });
 
         // Add extra cfg not defined in/by rustc
         //
@@ -1488,11 +1488,11 @@ impl<'a> Builder<'a> {
         // cargo would implicitly add it, it was discover that sometimes bootstrap only use
         // `rustflags` without `cargo` making it required.
         rustflags.arg("-Zunstable-options");
-        for (restricted_mode, _name, values) in EXTRA_CHECK_CFGS {
+        for (restricted_mode, name, values) in EXTRA_CHECK_CFGS {
             if *restricted_mode == None || *restricted_mode == Some(mode) {
                 // Creating a string of the values by concatenating each value:
                 // ',"tvos","watchos"' or '' (nothing) when there are no values
-                let _values = match values {
+                let values = match values {
                     Some(values) => values
                         .iter()
                         .map(|val| [",", "\"", val, "\""])
@@ -1500,7 +1500,7 @@ impl<'a> Builder<'a> {
                         .collect::<String>(),
                     None => String::new(),
                 };
-                // rustflags.arg(&format!("--check-cfg=values({name}{values})"));
+                rustflags.arg(&format!("--check-cfg=values({name}{values})"));
             }
         }
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -201,7 +201,7 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &'static str, Option<&[&'static str]>)]
     (Some(Mode::Std), "backtrace_in_libstd", None),
     /* Extra values not defined in the built-in targets yet, but used in std */
     (Some(Mode::Std), "target_env", Some(&["libnx"])),
-    (Some(Mode::Std), "target_os", Some(&["watchos"])),
+    (Some(Mode::Std), "target_os", Some(&["watchos", "theseus"])),
     (
         Some(Mode::Std),
         "target_arch",


### PR DESCRIPTION
rust-lang/rustc-dev-guide#1412 explains how to add a new target without
disabling all `--check-cfg` checks.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>