### PR TITLE
Add theseus target as an unrestricted `std`

### DIFF
--- a/library/std/src/sys_common/mod.rs
+++ b/library/std/src/sys_common/mod.rs
@@ -40,6 +40,7 @@ pub mod wtf8;
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "l4re",
                  target_os = "hermit",
+                 target_os = "theseus",
                  feature = "restricted-std",
                  all(target_family = "wasm", not(target_os = "emscripten")),
                  all(target_vendor = "fortanix", target_env = "sgx")))] {


### PR DESCRIPTION
This change allows us to compile `std` for the `x86_64-unknown-theseus`
target without needing `#![feature(restricted_std)]`.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>